### PR TITLE
adding share feature

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,7 @@ import cors from 'cors';
 import session from 'express-session';
 import path from 'path';
 import itineraryRouter from './routes/itineraries';
+import sharedItineraryRouter from './routes/sharedItineraries';
 import userRouter from './routes/users';
 import googleAuthRouter from './routes/googleAuth';
 import yelpFusionRouter from './routes/yelpFusion';
@@ -30,6 +31,9 @@ mongoose.connect(process.env.DATABASE_URL!, {
 
   // TODO: change to secure https://www.npmjs.com/package/express-session
   app.use(session({ resave: true, secret: process.env.EXPRESS_SESSION_SECRET!, saveUninitialized: true, cookie: { secure: false } }));
+
+  // place above middleware to allow un-authenticated users to view shareable itineraries
+  app.use('/api/shared/itineraries', sharedItineraryRouter);
 
   app.use(async (req: any, res, next) => {
     const user = await User.findById(req.session.userId).exec();

--- a/backend/src/database/models.ts
+++ b/backend/src/database/models.ts
@@ -1,6 +1,16 @@
 import "dotenv/config";
 import { Schema, model, ObjectId } from "mongoose";
 
+export interface IShareableItinerary {
+  itinerary_id: ObjectId;
+}
+
+export const shareableItinerarySchema = new Schema<IShareableItinerary>(
+  {
+    itinerary_id: { type: Schema.Types.ObjectId, required: true, unique: true },
+  },
+  { toObject: { versionKey: false } }
+);
 export interface IYelp {
   name: string;
   business_id: string;
@@ -178,3 +188,7 @@ export const User = model<IUser>("User", userSchema);
 export const Yelp = model<IYelp>("Yelp", yelpSchema);
 export const Itinerary = model<IItinerary>("Itinerary", itinerarySchema);
 export const Activity = model<IActivity>("Activity", activitySchema);
+export const ShareableItinerary = model<IShareableItinerary>(
+  "ShareableItinerary",
+  shareableItinerarySchema
+);

--- a/backend/src/routes/itineraries.ts
+++ b/backend/src/routes/itineraries.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { Itinerary, Activity } from "database/models";
+import { Itinerary, Activity, ShareableItinerary } from "database/models";
 
 const router = express.Router();
 
@@ -69,6 +69,20 @@ router.post("/", (req: any, res, _next) => {
     });
 });
 
+router.get("/shareable-link/:id", async (req: any, res, _next) => {
+  let query = { itinerary_id: req.params.id };
+  let update = { itinerary_id: req.params.id };
+  let options = { upsert: true, new: true, setDefaultsOnInsert: true };
+  let itinerary = await ShareableItinerary.findOneAndUpdate(
+    query,
+    update,
+    options
+  );
+  if (!itinerary) return res.status(404).send("Invalid Itinerary");
+  console.log(itinerary);
+  res.send(itinerary._id);
+});
+
 router.post("/new-activity", async (req: any, res, _next) => {
   const product = await Itinerary.findOne({
     $or: [
@@ -92,7 +106,7 @@ router.post("/new-activity", async (req: any, res, _next) => {
     })
     .catch((err) => {
       console.error(err);
-      return res.status(404).send({message: 'Invalid Activity'});
+      return res.status(404).send({ message: "Invalid Activity" });
     });
 });
 

--- a/backend/src/routes/sharedItineraries.ts
+++ b/backend/src/routes/sharedItineraries.ts
@@ -1,0 +1,15 @@
+import express from "express";
+import { Itinerary, ShareableItinerary } from "database/models";
+
+const router = express.Router();
+
+router.get("/:id", async (req: any, res, _next) => {
+  const { id } = req.params;
+  const shareObject = await ShareableItinerary.findOne({ _id: id });
+  if (!shareObject)
+    return res.status(404).send({ error: "This itinerary does not exist" });
+  const itinerary = await Itinerary.findOne({ _id: shareObject.itinerary_id });
+  res.status(200).send(itinerary);
+});
+
+export default router;

--- a/trippo/package.json
+++ b/trippo/package.json
@@ -9,6 +9,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/pickers": "^3.3.10",
+    "@react-pdf/renderer": "^2.0.18",
     "@reduxjs/toolkit": "^1.6.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/trippo/src/App.tsx
+++ b/trippo/src/App.tsx
@@ -50,9 +50,11 @@ function App() {
       })
       .catch((e: string) => {
         window.localStorage.removeItem("user");
+        console.log(history);
         if (
           history.location.pathname !== "/about" &&
-          history.location.pathname !== "/"
+          history.location.pathname !== "/" &&
+          !history.location.pathname.includes("/shared")
         )
           history.push("/");
       });
@@ -84,6 +86,7 @@ function App() {
       <Switch>
         <Route exact path="/" component={() => <WelcomePage />} />
         <Route exact path="/about" component={() => <AboutPage />} />
+        <Route exact path="/shared/:id" component={() => <ItineraryPage />} />
         <PrivateRoute
           exact
           path="/itinerary/:id"

--- a/trippo/src/components/itineraryPDF/ItineraryPDF.tsx
+++ b/trippo/src/components/itineraryPDF/ItineraryPDF.tsx
@@ -1,0 +1,192 @@
+import React, { FC } from "react";
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+  Link,
+  Image,
+} from "@react-pdf/renderer";
+import { Activity, Itinerary } from "types/models";
+import { getDates } from "../itineraryReadOnlyView/ItineraryReadOnlyView";
+import moment from "moment";
+
+interface Props {
+  itinerary: Itinerary;
+}
+
+const days = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
+
+// Create styles
+const styles = StyleSheet.create({
+  page: {
+    flexDirection: "column",
+    fontSize: 12,
+    padding: 20,
+  },
+  section: {
+    flexGrow: 1,
+    flexDirection: "column",
+  },
+  activityContent: {
+    marginBottom: 5,
+    padding: 7,
+  },
+  address: {
+    color: "#474747",
+    paddingTop: 4,
+  },
+  comments: {
+    paddingTop: 7,
+    paddingLeft: 12,
+  },
+  activity: {
+    margin: 7,
+    flexDirection: "row",
+    alignItems: "center",
+    borderTopWidth: 1,
+    borderTopColor: "#F4F4F4 ",
+    borderLeftWidth: 1,
+    borderLeftColor: "#F4F4F4 ",
+    borderBottomColor: "#EEEEEE",
+    borderBottomWidth: 2,
+    borderRightColor: "#EEEEEE",
+    borderRightWidth: 2,
+    borderTopLeftRadius: 5,
+    borderTopRightRadius: 5,
+    borderBottomRightRadius: 5,
+    borderBottomLeftRadius: 5,
+  },
+  date: {
+    paddingLeft: 5,
+    color: "#219EBC",
+  },
+  destination: {
+    fontSize: 14,
+  },
+  dateContainer: {
+    flexDirection: "row",
+    paddingBottom: 8,
+  },
+  day: {
+    alignSelf: "flex-end",
+  },
+  destinationHeader: {
+    alignSelf: "center",
+    fontSize: 15,
+    paddingBottom: 8,
+  },
+  title: {
+    flexDirection: "column",
+    alignSelf: "center",
+    alignItems: "center",
+  },
+  titlePage: {
+    justifyContent: "center",
+    display: "flex",
+    fontSize: 20,
+  },
+  logo: {
+    width: 200,
+  },
+  titleDates: {
+    fontSize: 12,
+    paddingTop: 4,
+  },
+  time: {
+    padding: 5,
+  },
+  headerComments: {
+    fontSize: 14,
+    paddingTop: 8,
+    color: "#474747",
+  },
+});
+// Create Document Component
+const ItineraryPDF: FC<Props> = ({ itinerary }) => {
+  const dates = itinerary && getDates(itinerary.start_date, itinerary.end_date);
+  return (
+    <Document>
+      <Page orientation="landscape" size="A4" style={styles.titlePage}>
+        <View style={styles.title}>
+          <Image style={styles.logo} src="/trippo.png" />
+          <Link
+            src={`https://trippoapp.herokuapp.com/itinerary/${itinerary._id}`}
+          >
+            {itinerary.name}
+          </Link>
+          <Text style={styles.titleDates}>
+            {moment(itinerary?.start_date).format("MMM Do YYYY") +
+              ` - ` +
+              moment(itinerary?.end_date).format("MMM Do YYYY")}
+          </Text>
+          <Text style={styles.headerComments}>{itinerary.comments}</Text>
+        </View>
+      </Page>
+      {dates?.map((date) => {
+        const dayActivities = itinerary?.activities.filter((activity: any) =>
+          moment(date).isSame(moment(activity.time), "date")
+        );
+        return (
+          <Page orientation="landscape" size="A4" style={styles.page}>
+            <View style={styles.destinationHeader}>
+              <Link
+                src={`https://trippoapp.herokuapp.com/itinerary/${itinerary._id}`}
+              >
+                {itinerary.destination}
+              </Link>
+            </View>
+            <View style={styles.dateContainer} fixed>
+              <Text style={styles.date}>
+                {moment(date).format("MMMM Do YYYY")}
+              </Text>
+              <Text style={styles.date}>
+                {days[moment(date).isoWeekday() - 1]}
+              </Text>
+            </View>
+            <View style={styles.section}>
+              {dayActivities
+                .sort((a, b) => a.time.localeCompare(b.time))
+                .map((activity: Activity) => {
+                  return (
+                    <View style={styles.activity} wrap={false}>
+                      <Text style={styles.time}>
+                        {moment(
+                          new Date(activity.time),
+                          "dd DD-MMM-YYYY, hh:mm"
+                        ).format("hh:mm A")}
+                      </Text>
+                      <View style={styles.activityContent}>
+                        <Text style={styles.destination}>
+                          {activity.destination}
+                        </Text>
+                        <Text style={styles.address}>{activity.address}</Text>
+                        {activity.comments?.length > 0 &&
+                          activity.comments[0] !== "" &&
+                          activity.comments.map((comment) => (
+                            <Text
+                              style={styles.comments}
+                            >{`•  ${comment}`}</Text>
+                          ))}
+                      </View>
+                    </View>
+                  );
+                })}
+            </View>
+          </Page>
+        );
+      })}
+    </Document>
+  );
+};
+
+export default ItineraryPDF;

--- a/trippo/src/components/itineraryPage/ItineraryPage.styles.ts
+++ b/trippo/src/components/itineraryPage/ItineraryPage.styles.ts
@@ -2,6 +2,10 @@ import styled from "styled-components";
 import * as c from "../../colors/colors";
 import Button from "@material-ui/core/Button";
 
+export interface DisabledButtonProps {
+  disabled: boolean;
+}
+
 export const fancytext = styled.div`
   text-align: center;
   font-style: italic;
@@ -51,7 +55,7 @@ export const LoadingDiv = styled.div`
   }
 `;
 
-export const SideBar = styled.div`
+export const SideBar = styled.div<DisabledButtonProps>`
   z-index: 1;
   height: 95%;
   width: 2em;
@@ -65,13 +69,14 @@ export const SideBar = styled.div`
     padding: 0;
     background-color: ${c.DARK_BLUE};
     i {
+      padding-top: 100%;
       display: inline;
       color: ${c.WHITE};
       font-size: 1.5em;
     }
   }
   button:hover {
-    cursor: pointer;
+    cursor: ${(props) => (props.disabled ? `not-allowed` : `pointer`)};
   }
 
   @media (max-width: 668px) {

--- a/trippo/src/components/itineraryPage/ItineraryPage.styles.ts
+++ b/trippo/src/components/itineraryPage/ItineraryPage.styles.ts
@@ -1,7 +1,19 @@
 import styled from "styled-components";
 import * as c from "../../colors/colors";
 import Button from "@material-ui/core/Button";
+import PictureAsPdfIcon from "@material-ui/icons/PictureAsPdf";
+import { PDFDownloadLink } from "@react-pdf/renderer";
 
+export const StyledPDFDownloadLink = styled(PDFDownloadLink)`
+  background: ${c.DARK_BLUE};
+  padding-top: 5px;
+`;
+
+export const StyledPictureAsPdfIcon = styled(PictureAsPdfIcon)`
+  color: ${c.WHITE};
+  padding: 1px;
+  padding-left: 1.5px;
+`;
 export interface DisabledButtonProps {
   disabled: boolean;
 }
@@ -29,7 +41,7 @@ export const dayDiv = styled.div`
 `;
 
 export const StyledViewListIcon = styled.div`
-  padding: 1em 0;
+  padding: 0.5em 0;
   display: flex;
   justify-content: center;
   color: ${c.WHITE};

--- a/trippo/src/components/itineraryPage/ItineraryPage.tsx
+++ b/trippo/src/components/itineraryPage/ItineraryPage.tsx
@@ -8,6 +8,7 @@ import { GeocoderContainer } from "components/map/Map.styles";
 import Searchbar from "components/searchBar/Searchbar";
 import ViewListIcon from "@material-ui/icons/ViewList";
 import NewSlot from "components/itineraryEdit/NewSlot";
+import ItineraryPDF from "../itineraryPDF/ItineraryPDF";
 import {
   Dialog,
   DialogActions,
@@ -323,6 +324,18 @@ function ItineraryPage() {
             setSearchResult={setSearchResult}
           />
           <sc.SideBar disabled={IS_SHARED}>
+            {itinerary && (
+              <sc.StyledPDFDownloadLink
+                document={<ItineraryPDF itinerary={itinerary} />}
+                fileName={`${itinerary.name.replace(/\s/g, "_")}.pdf`}
+              >
+                {() => (
+                  <Tooltip title="Export to PDF" aria-label="Export to PDF">
+                    <sc.StyledPictureAsPdfIcon />
+                  </Tooltip>
+                )}
+              </sc.StyledPDFDownloadLink>
+            )}
             <sc.StyledViewListIcon>
               <Tooltip
                 title="Itinerary master plan"

--- a/trippo/src/components/itineraryReadOnlyView/ItineraryReadOnlyView.tsx
+++ b/trippo/src/components/itineraryReadOnlyView/ItineraryReadOnlyView.tsx
@@ -2,20 +2,20 @@ import React from "react";
 import * as sc from "./ItineraryReadOnlyView.styles";
 import Day from "../itineraryEdit/Day";
 import moment from "moment";
+import ItineraryPDF from "../itineraryPDF/ItineraryPDF";
 import { useAppSelector } from "app/store";
 
+export const getDates = (startDate: Date, endDate: Date): string[] => {
+  let dateArray: string[] = [];
+  let currentDate = moment(startDate);
+  let stopDate = moment(endDate);
+  while (currentDate <= stopDate) {
+    dateArray.push(moment(currentDate).format("YYYY-MM-DD"));
+    currentDate = moment(currentDate).add(1, "days");
+  }
+  return dateArray;
+};
 function ItineraryReadOnlyView() {
-  const getDates = (startDate: Date, endDate: Date): string[] => {
-    let dateArray: string[] = [];
-    let currentDate = moment(startDate);
-    let stopDate = moment(endDate);
-    while (currentDate <= stopDate) {
-      dateArray.push(moment(currentDate).format("YYYY-MM-DD"));
-      currentDate = moment(currentDate).add(1, "days");
-    }
-    return dateArray;
-  };
-
   const itinerary = useAppSelector((state) => state.itinerary.value);
   const dates = itinerary && getDates(itinerary.start_date, itinerary.end_date);
   return (

--- a/trippo/src/components/map/Map.css
+++ b/trippo/src/components/map/Map.css
@@ -1,4 +1,11 @@
 .marker {
-  cursor: pointer;
   filter: drop-shadow(-3px 5px 3px rgba(0, 0, 0, 0.2));
+}
+
+.pointer {
+  cursor: pointer;
+}
+
+.disable {
+  cursor: not-allowed;
 }

--- a/trippo/src/components/map/Map.tsx
+++ b/trippo/src/components/map/Map.tsx
@@ -17,6 +17,7 @@ import {
   ContextInterface,
   ItineraryContext,
 } from "../itineraryPage/ItineraryPage";
+import { useHistory } from "react-router-dom";
 import "./Map.css";
 import { ActivityPopup } from "types/models";
 import { useAppSelector } from "app/store";
@@ -86,6 +87,8 @@ const Map: FC<Props> = ({
     zoom: 2,
   });
 
+  const history = useHistory();
+  const IS_SHARED = history.location.pathname.includes("/shared");
   const itinerary = useAppSelector((state) => state.itinerary.value);
 
   const bbox =
@@ -105,12 +108,14 @@ const Map: FC<Props> = ({
   useEffect(() => {
     if (itinerary) {
       const longitude =
-        window.innerWidth <= 700
+        window.innerWidth <= 700 || IS_SHARED
           ? itinerary.dest_coords.lng
           : itinerary.dest_coords.lng - 0.2;
       setViewport({
         longitude: !isFirstLoad ? viewport.longitude : longitude,
-        latitude: !isFirstLoad ? viewport.latitude : itinerary.dest_coords.lat,
+        latitude: !isFirstLoad
+          ? viewport.latitude
+          : itinerary.dest_coords.lat - 0.1,
         zoom: 10,
         transitionDuration: 400,
         pitch: 30,
@@ -145,7 +150,7 @@ const Map: FC<Props> = ({
             offsetTop={-41}
           >
             <Pin
-              className="marker"
+              className="marker pointer"
               onClick={() => {
                 itineraryContext?.handleSetActivityPopups(slot);
               }}
@@ -188,20 +193,22 @@ const Map: FC<Props> = ({
           offsetTop={-41}
         >
           <Pin
-            className="marker"
+            className={`marker ${IS_SHARED ? `disable` : `pointer`}`}
             onClick={async () => {
-              handleNewSlotClick(
-                await reverseGeocodeName(
+              if (!IS_SHARED) {
+                handleNewSlotClick(
+                  await reverseGeocodeName(
+                    searchResult.geometry.coordinates[1],
+                    searchResult.geometry.coordinates[0]
+                  ),
+                  await reverseGeocodeAddress(
+                    searchResult.geometry.coordinates[1],
+                    searchResult.geometry.coordinates[0]
+                  ),
                   searchResult.geometry.coordinates[1],
                   searchResult.geometry.coordinates[0]
-                ),
-                await reverseGeocodeAddress(
-                  searchResult.geometry.coordinates[1],
-                  searchResult.geometry.coordinates[0]
-                ),
-                searchResult.geometry.coordinates[1],
-                searchResult.geometry.coordinates[0]
-              );
+                );
+              }
             }}
             fill={DARK_ORANGE}
           />

--- a/trippo/src/components/navBar/Navbar.styles.ts
+++ b/trippo/src/components/navBar/Navbar.styles.ts
@@ -1,9 +1,21 @@
 import { makeStyles } from "@material-ui/core/styles";
+import IconButton from "@material-ui/core/IconButton";
+import { Button, Tooltip } from "@material-ui/core";
 import { Grid } from "@material-ui/core";
 import styled from "styled-components";
 import * as c from "../../colors/colors";
 
 const drawerWidth = 240;
+
+export const StyledButton = styled(Button)`
+  span {
+    color: ${c.DARK_ORANGE};
+  }
+`;
+
+export const StyledTooltip = styled(Tooltip)`
+  margin-left: 0.5em;
+`;
 
 export const Logo = styled.div`
   position: absolute;
@@ -40,6 +52,15 @@ export const ItineraryTitle = styled.div`
   }
 `;
 
+export const StyledLink = styled.input`
+  width: 100%;
+  border: none;
+  border-color: transparent;
+  :focus {
+    border: none;
+  }
+`;
+
 export const LogoButton = styled.button`
   &:hover {
     cursor: pointer;
@@ -60,6 +81,13 @@ export const LogoButton = styled.button`
       display: block;
     }
   }
+`;
+
+export const StyledIconButton = styled(IconButton)`
+  width: 24px !important;
+  height: 24px !important;
+  margin-top: -6px;
+  position: relative;
 `;
 
 export const useStyles = makeStyles((theme) => ({

--- a/trippo/src/components/navBar/Navbar.tsx
+++ b/trippo/src/components/navBar/Navbar.tsx
@@ -12,6 +12,15 @@ import MenuIcon from "@material-ui/icons/Menu";
 import ChevronLeftIcon from "@material-ui/icons/ChevronLeft";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import AccountCircle from "@material-ui/icons/AccountCircle";
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Tooltip,
+} from "@material-ui/core";
+import LinkIcon from "@material-ui/icons/Link";
 import { setUser } from "app/reducers/userSlice";
 import ListItem from "@material-ui/core/ListItem";
 import Menu from "@material-ui/core/Menu";
@@ -28,10 +37,13 @@ import * as sc from "./Navbar.styles";
 
 const Navbar = (props: { history: any }) => {
   const { history } = props;
+  const IS_SHARED = history.location.pathname.includes("/shared");
   const classes = useStyles();
   const theme = useTheme();
   const [open, setOpen] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
+  const [isShareableLinkOpen, setIsShareableLinkOpen] = React.useState(false);
+  const [sharedID, setSharedID] = React.useState(null);
 
   const user = useAppSelector((state) => state.user.value);
   const itinerary = useAppSelector((state) => state.itinerary.value);
@@ -52,12 +64,64 @@ const Navbar = (props: { history: any }) => {
         credentials: "include",
       });
       dispatch(setUser({ isLoggedIn: false }));
-      window.localStorage.removeItem('user');
+      window.localStorage.removeItem("user");
       handleMenuClick("/");
     } catch (e) {
       console.log(e);
     }
     // store returned user somehow
+  };
+
+  const handleGetShareableLink = async () => {
+    try {
+      const res = await fetch(
+        `/api/itineraries/shareable-link/` + itinerary?._id,
+        {
+          method: "GET",
+          credentials: "include",
+        }
+      );
+      const id = await res.json();
+      setSharedID(id);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const getInvalidItineraryDialog = () => {
+    const link: string = "https://trippoapp.herokuapp.com/shared/" + sharedID;
+    return (
+      <Dialog
+        open={isShareableLinkOpen && sharedID !== null}
+        onClose={() => setIsShareableLinkOpen(false)}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          Anyone with this link has <strong>restricted</strong> read-only
+          access.
+          <br />
+          <sc.StyledLink value={link} />
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            To allow read and write access, add collaborators to your itinerary!
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <sc.StyledButton
+            onClick={() => {
+              if (navigator.clipboard) navigator.clipboard.writeText(link);
+              setIsShareableLinkOpen(false);
+            }}
+            color="primary"
+            autoFocus
+          >
+            Copy link
+          </sc.StyledButton>
+        </DialogActions>
+      </Dialog>
+    );
   };
 
   const handleDrawerOpen = () => {
@@ -121,10 +185,28 @@ const Navbar = (props: { history: any }) => {
               </>
             </sc.LogoButton>
           </sc.Logo>
-          {history.location.pathname.includes("itinerary") && itinerary ? (
+          {(history.location.pathname.includes("itinerary") || IS_SHARED) &&
+          itinerary ? (
             <sc.ItineraryTitle>
               <FadeIn transitionDuration={600} delay={500}>
-                {itinerary?.name}
+                <div>
+                  {itinerary?.name}
+                  {!IS_SHARED && (
+                    <sc.StyledTooltip
+                      title="Get shareable link"
+                      aria-label="Get shareable link"
+                    >
+                      <sc.StyledIconButton
+                        onClick={() => {
+                          setIsShareableLinkOpen(true);
+                          handleGetShareableLink();
+                        }}
+                      >
+                        <LinkIcon />
+                      </sc.StyledIconButton>
+                    </sc.StyledTooltip>
+                  )}
+                </div>
                 <sc.DateGrid container item lg={12} sm={12}>
                   <i className="far fa-calendar-alt"></i>
                   {moment(itinerary?.start_date).format("MMM Do YYYY") +
@@ -200,11 +282,12 @@ const Navbar = (props: { history: any }) => {
               </ListItem>
             );
           })}
-          <ListItem button onClick={() => handleMenuClick('/about')}>
-            {'About'}
+          <ListItem button onClick={() => handleMenuClick("/about")}>
+            {"About"}
           </ListItem>
         </List>
       </Drawer>
+      {getInvalidItineraryDialog()}
     </div>
   );
 };

--- a/trippo/yarn.lock
+++ b/trippo/yarn.lock
@@ -1147,6 +1147,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.4.3", "@babel/runtime@^7.6.2":
+  version "7.14.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
+  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1870,6 +1877,148 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@react-pdf/font@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@react-pdf/font/-/font-2.0.11.tgz#940df37e3c00338e2e1bfdb5091e0a424ae98bdc"
+  integrity sha512-QM0sjMJRrhuzl166sxkFWNttAQmAjDA+ossk+0RFuJUargoa8GjqznXb+yH2M6lm/A8MNS4JWNHUlwFjvC3g2g==
+  dependencies:
+    "@react-pdf/fontkit" "^2.0.6"
+    "@react-pdf/types" "^2.0.4"
+    cross-fetch "^3.0.4"
+    is-url "^1.2.4"
+
+"@react-pdf/fontkit@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@react-pdf/fontkit/-/fontkit-2.0.6.tgz#1aad76bba2e7925631824e54a98ae9b63a888428"
+  integrity sha512-9l85jaY8WiyLHMZvh4d08q5TMWPRwqZIwN6uLzqaoMjMqJ1A3I6StE5kaxvEGVxvFvAeExHfFVgKdyeFmLQg4g==
+  dependencies:
+    "@react-pdf/unicode-properties" "^2.4.1"
+    brotli "^1.2.0"
+    clone "^1.0.4"
+    deep-equal "^1.0.0"
+    dfa "1.1.0"
+    restructure "^0.5.3"
+    tiny-inflate "^1.0.2"
+    unicode-trie "^0.3.0"
+
+"@react-pdf/image@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@react-pdf/image/-/image-2.0.3.tgz#6d20b86b7adc286573cd09a31842a29b8ff09817"
+  integrity sha512-7PbId4yS1VCOj3rkeLsA8OmPiah2nkLXbBIxBpq/pyU+vcc0EqBhzSy/9Wkhw23uV5AZxE26V+ngMNhWdcgctw==
+  dependencies:
+    "@react-pdf/png-js" "^2.0.2"
+    cross-fetch "^3.0.4"
+
+"@react-pdf/layout@^2.0.18":
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/@react-pdf/layout/-/layout-2.0.18.tgz#4106d4181514b6481053d054687d6150fd872fe0"
+  integrity sha512-Js8uMfdIS8LfzNlOrXKKItU4xZB7nt2Ck0v6psYlEsczY1kiF/nuBw1EdRHMv5BNpbrW29VvBjPfy4rGHf6ZqQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-pdf/image" "^2.0.3"
+    "@react-pdf/pdfkit" "^2.0.11"
+    "@react-pdf/primitives" "^2.0.0"
+    "@react-pdf/stylesheet" "^2.0.10"
+    "@react-pdf/textkit" "^2.0.6"
+    "@react-pdf/types" "^2.0.4"
+    "@react-pdf/yoga" "^2.0.2"
+    cross-fetch "^3.0.4"
+    emoji-regex "^8.0.0"
+    queue "^6.0.1"
+    ramda "^0.26.1"
+
+"@react-pdf/pdfkit@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@react-pdf/pdfkit/-/pdfkit-2.0.11.tgz#60f8fa9a5121f16da6c013c6a956a0a9cb46909c"
+  integrity sha512-cQYgatQeyZe7UcSJyN4ZPUiDG90heyYMrwHQYaH+1sJIXYRNoxTfHb4ubjjQ3K3bJAzrMMn/CSW92ngiQWUYSg==
+  dependencies:
+    "@react-pdf/fontkit" "^2.0.6"
+    "@react-pdf/png-js" "^2.0.2"
+    crypto-js "^4.0.0"
+
+"@react-pdf/png-js@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@react-pdf/png-js/-/png-js-2.0.2.tgz#1267f7a02701433dac1db88e07cf55b3771c7139"
+  integrity sha512-hdOxW8JiWKy1JtocfMG6RhNFRLJeJIHOdAPg9CNpg4Az7PrDdtPoEZfQ1rXSuPhX2iHH5Brfb3Epv+VvUl7BKg==
+
+"@react-pdf/primitives@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@react-pdf/primitives/-/primitives-2.0.0.tgz#2a97ef32c97050e0039a427d73f673da3bd914b5"
+  integrity sha512-Yh8TEjzyObnalM271znZVJsy6BiY+s6uTOCjLJL8jSvU1rGA1p45VjK7AnNpgH+n+JzpddXQweT2oE2HWGuYFA==
+
+"@react-pdf/render@^2.0.12":
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/@react-pdf/render/-/render-2.0.12.tgz#c9ed8c9af075ae2233d2b277ac1ba68fba316c8d"
+  integrity sha512-D61o5ELVqhfYDlEHe+5kFy+DdcnKjzB5oF/RYU9jyXYlEg86KBPyLMONXd08ZVpfIczbn8UwyUu7SuHy41LzEQ==
+  dependencies:
+    "@react-pdf/primitives" "^2.0.0"
+    "@react-pdf/textkit" "^2.0.6"
+    "@react-pdf/types" "^2.0.4"
+    abs-svg-path "^0.1.1"
+    color-string "^1.5.3"
+    normalize-svg-path "^1.1.0"
+    parse-svg-path "^0.1.2"
+    ramda "^0.26.1"
+    svg-arc-to-cubic-bezier "^3.2.0"
+
+"@react-pdf/renderer@^2.0.18":
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/@react-pdf/renderer/-/renderer-2.0.18.tgz#38150482cf13e19bb84aab90c304799f0343c0f2"
+  integrity sha512-gOEROOyp3YAYp6HlxjzqBGCnUorJCYW63bafdyFhV33CYPzF50scPI/By+/llsPCXKT3PtlBBcD/2Y/5Ka8wgg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-pdf/font" "^2.0.11"
+    "@react-pdf/layout" "^2.0.18"
+    "@react-pdf/pdfkit" "^2.0.11"
+    "@react-pdf/primitives" "^2.0.0"
+    "@react-pdf/render" "^2.0.12"
+    "@react-pdf/types" "^2.0.4"
+    blob-stream "^0.1.3"
+    queue "^6.0.1"
+    ramda "^0.26.1"
+    react-reconciler "^0.23.0"
+    scheduler "^0.15.0"
+
+"@react-pdf/stylesheet@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@react-pdf/stylesheet/-/stylesheet-2.0.10.tgz#768a80b071e840aa837fe280914c4a1e0c3a10b1"
+  integrity sha512-KKeFkPl7qvjpoZE1adyLY+r1JhFZdHaUabqH3FBl7LgWHOMqDu5MvVTig4YxQ0WjzqwQU8Oh9rbhme8Z4JFaAA==
+  dependencies:
+    "@react-pdf/types" "^2.0.4"
+    color-string "^1.5.3"
+    hsl-to-hex "^1.0.0"
+    media-engine "^1.0.3"
+    ramda "^0.26.1"
+
+"@react-pdf/textkit@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@react-pdf/textkit/-/textkit-2.0.6.tgz#12fa9dfcef5da1f552dd92ac7983a029ce569e25"
+  integrity sha512-B+pZpiAKPZ4shGv9/rRspZX6O9P6u1gfsXcGiS2/o9LAGIspoNuSE217Ir7oRKUqHtPdYslviY42AzvY4nes3g==
+  dependencies:
+    "@babel/runtime" "^7.4.3"
+    "@react-pdf/unicode-properties" "^2.4.1"
+    hyphen "^1.6.4"
+    ramda "^0.26.1"
+
+"@react-pdf/types@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@react-pdf/types/-/types-2.0.4.tgz#727f6ad53c5084a255c07943a0023a2d042431e8"
+  integrity sha512-6UJGPg6dhrhwz2I5UWPiDAahPoOWdAotyheHRL3PjqemjR+JD2ReSjTrLXczC0SufTMKV4NW9ZtFbru0hSCVDA==
+
+"@react-pdf/unicode-properties@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@react-pdf/unicode-properties/-/unicode-properties-2.4.1.tgz#7e0dd41537e9d91e18c8a3bbab0c15a2b86df2dc"
+  integrity sha512-B6jnyp7KaTcQeWbkk5wlBEWrGrsGAMtcWVHIyUArBK2HXo3CDkCyx3/AiRsZYgBLBJzjmD7Qv6nPK9ksXNQD/Q==
+  dependencies:
+    unicode-trie "^0.3.0"
+
+"@react-pdf/yoga@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@react-pdf/yoga/-/yoga-2.0.2.tgz#5d23a70ec86f4b166fa5fcb03454e742cbb865de"
+  integrity sha512-BKEbxIw1XHy3BDYAaOOjrJRLQZUmh+DIv+WIYO6MbwPXP7WLhbggqhC1MOLS3ZyNyBC12VInsYEdpF1l5ia3ng==
+  dependencies:
+    "@types/yoga-layout" "^1.9.3"
+
 "@reduxjs/toolkit@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.6.0.tgz#0a17c6941c57341f8b31e982352b495ab69d5add"
@@ -2447,6 +2596,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yoga-layout@^1.9.3":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@types/yoga-layout/-/yoga-layout-1.9.4.tgz#fad54fef623464dacd9e765d854f0e76ff1184f7"
+  integrity sha512-RRHc1+8Hc5mf/2lZKnom6kCnqcNS07s8keahniWTOva0KELF6RgDJmaEcvGEKUUJgN4UgessmEsWuidaOycIOw==
+
 "@typescript-eslint/eslint-plugin@^4.5.0":
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.2.tgz#981b26b4076c62a5a55873fbef3fe98f83360c61"
@@ -2718,6 +2872,11 @@ abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abs-svg-path@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/abs-svg-path/-/abs-svg-path-0.1.1.tgz#df601c8e8d2ba10d4a76d625e236a9a39c2723bf"
+  integrity sha1-32Acjo0roQ1KdtYl4japo5wnI78=
 
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
@@ -3101,10 +3260,24 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-transform@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/ast-transform/-/ast-transform-0.0.0.tgz#74944058887d8283e189d954600947bc98fe0062"
+  integrity sha1-dJRAWIh9goPhidlUYAlHvJj+AGI=
+  dependencies:
+    escodegen "~1.2.0"
+    esprima "~1.0.4"
+    through "~2.3.4"
+
 ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
+ast-types@^0.7.0:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.7.8.tgz#902d2e0d60d071bdcd46dc115e1809ed11c138a9"
+  integrity sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -3347,7 +3520,7 @@ babel-preset-react-app@^10.0.0:
     babel-plugin-macros "2.8.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
 
-babel-runtime@^6.26.0:
+babel-runtime@^6.11.6, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -3370,7 +3543,7 @@ base-64@^0.1.0:
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -3451,6 +3624,18 @@ bl@^2.2.1:
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
+
+blob-stream@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/blob-stream/-/blob-stream-0.1.3.tgz#98d668af6996e0f32ef666d06e215ccc7d77686c"
+  integrity sha1-mNZor2mW4PMu9mbQbiFczH13aGw=
+  dependencies:
+    blob "0.0.4"
+
+blob@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
+  integrity sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=
 
 block-stream@*:
   version "0.0.9"
@@ -3548,10 +3733,24 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
+brotli@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.2.tgz#525a9cad4fcba96475d7d388f6aecb13eed52f46"
+  integrity sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=
+  dependencies:
+    base64-js "^1.1.2"
+
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
+
+browser-resolve@^1.8.1:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
+  dependencies:
+    resolve "1.1.7"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
@@ -3583,6 +3782,15 @@ browserify-des@^1.0.0:
     des.js "^1.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+browserify-optional@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-optional/-/browserify-optional-1.0.1.tgz#1e13722cfde0d85f121676c2a72ced533a018869"
+  integrity sha1-HhNyLP3g2F8SFnbCpyztUzoBiGk=
+  dependencies:
+    ast-transform "0.0.0"
+    ast-types "^0.7.0"
+    browser-resolve "^1.8.1"
 
 browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
   version "4.1.0"
@@ -4120,7 +4328,7 @@ clone-response@1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clone@^1.0.2:
+clone@^1.0.2, clone@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
@@ -4192,6 +4400,14 @@ color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.3:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.6.0.tgz#c3915f61fe267672cb7e1e064c9d692219f6c312"
+  integrity sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-string@^1.5.4:
   version "1.5.4"
@@ -4488,6 +4704,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@^3.0.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -4532,6 +4755,11 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -4909,7 +5137,7 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-equal@^1.0.1:
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
   integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
@@ -5046,6 +5274,13 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+dfa@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/dfa/-/dfa-1.1.0.tgz#d30218bd10d030fa421df3ebbc82285463a31781"
+  integrity sha1-0wIYvRDQMPpCHfPrvIIoVGOjF4E=
+  dependencies:
+    babel-runtime "^6.11.6"
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -5476,6 +5711,17 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+escodegen@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.2.0.tgz#09de7967791cc958b7f89a2ddb6d23451af327e1"
+  integrity sha1-Cd55Z3kcyVi3+Jot220jRRrzJ+E=
+  dependencies:
+    esprima "~1.0.4"
+    estraverse "~1.5.0"
+    esutils "~1.0.0"
+  optionalDependencies:
+    source-map "~0.1.30"
+
 eslint-config-react-app@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz#ccff9fc8e36b322902844cbd79197982be355a0e"
@@ -5680,6 +5926,11 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
+esprima@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
+  integrity sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=
+
 esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
@@ -5704,6 +5955,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estraverse@~1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
+  integrity sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=
+
 estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
@@ -5718,6 +5974,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+esutils@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.0.0.tgz#8151d358e20c8acc7fb745e7472c0025fe496570"
+  integrity sha1-gVHTWOIMisx/t0XnRywAJf5JZXA=
 
 etag@~1.8.1:
   version "1.8.1"
@@ -6715,6 +6976,18 @@ hsl-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
   integrity sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=
 
+hsl-to-hex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz#c58c826dc6d2f1e0a5ff1da5a7ecbf03faac1352"
+  integrity sha1-xYyCbcbS8eCl/x2lp+y/A/qsE1I=
+  dependencies:
+    hsl-to-rgb-for-reals "^1.1.0"
+
+hsl-to-rgb-for-reals@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz#e1eb23f6b78016e3722431df68197e6dcdc016d9"
+  integrity sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==
+
 hsla-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
@@ -6905,6 +7178,11 @@ husky@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
   integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
+
+hyphen@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/hyphen/-/hyphen-1.6.4.tgz#9859678fe1af2793b49e7d466e85f85b5698917e"
+  integrity sha512-nWwvXceFMAFIjkiRzqZMZSOa1LVngieSolnYIVKWSwmDwMSmdutjzqImmdbxe2eUCfX693fgrCgtPjbllqx1lA==
 
 hyphenate-style-name@^1.0.3:
   version "1.0.4"
@@ -7510,6 +7788,11 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -8868,6 +9151,11 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
+media-engine@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/media-engine/-/media-engine-1.0.3.tgz#be3188f6cd243ea2a40804a35de5a5b032f58dad"
+  integrity sha1-vjGI9s0kPqKkCASjXeWlsDL1ja0=
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -9381,6 +9669,11 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
@@ -9549,6 +9842,13 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
+
+normalize-svg-path@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz#0e614eca23c39f0cffe821d6be6cd17e569a766c"
+  integrity sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==
+  dependencies:
+    svg-arc-to-cubic-bezier "^3.0.0"
 
 normalize-url@1.9.1:
   version "1.9.1"
@@ -10113,6 +10413,11 @@ pacote@^11.1.11, pacote@^11.2.6, pacote@^11.3.0, pacote@^11.3.1, pacote@^11.3.3:
     ssri "^8.0.1"
     tar "^6.1.0"
 
+pako@^0.2.5:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+  integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
+
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -10186,6 +10491,11 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-svg-path@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/parse-svg-path/-/parse-svg-path-0.1.2.tgz#7a7ec0d1eb06fa5325c7d3e009b859a09b5d49eb"
+  integrity sha1-en7A0esG+lMlx9PgCbhZoJtdSes=
 
 parse5@5.1.1:
   version "5.1.1"
@@ -11364,6 +11674,13 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
   integrity sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
 
+queue@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
+
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
@@ -11380,6 +11697,11 @@ raf@^3.4.1:
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
+
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
@@ -11529,6 +11851,16 @@ react-nice-dates@^3.1.0:
   integrity sha512-tOsA7tB2E9q+47nZwrk2ncK2rOUublNOWPVnY/N2HFDLO8slexGaAfOTKpej2KzPxCN3gcvOKeE2/9vua2LAjQ==
   dependencies:
     classnames "^2.2.6"
+
+react-reconciler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.23.0.tgz#5f0bfc35dda030b0220c07de11f93131c5d6db63"
+  integrity sha512-vV0KlLimP9a/NuRcM6GRVakkmT6MKSzhfo8K72fjHMnlXMOhz9GlPe+/tCp5CWBkg+lsMUt/CR1nypJBTPfwuw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.17.0"
 
 react-redux@^7.2.4:
   version "7.2.4"
@@ -12082,6 +12414,11 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+
 resolve@1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
@@ -12112,6 +12449,13 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+
+restructure@^0.5.3:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/restructure/-/restructure-0.5.4.tgz#f54e7dd563590fb34fd6bf55876109aeccb28de8"
+  integrity sha1-9U591WNZD7NP1r9Vh2EJrsyyjeg=
+  dependencies:
+    browserify-optional "^1.0.0"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -12334,6 +12678,22 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"
+  integrity sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.20.2:
   version "0.20.2"
@@ -12771,6 +13131,13 @@ source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+source-map@~0.1.30:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
+  dependencies:
+    amdefine ">=0.0.4"
 
 sourcemap-codec@^1.4.4:
   version "1.4.8"
@@ -13232,6 +13599,11 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+svg-arc-to-cubic-bezier@^3.0.0, svg-arc-to-cubic-bezier@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz#390c450035ae1c4a0104d90650304c3bc814abe6"
+  integrity sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==
+
 svg-parser@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
@@ -13399,7 +13771,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@^2.3.8:
+through@^2.3.8, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -13425,6 +13797,11 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-inflate@^1.0.0, tiny-inflate@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
+  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
 tiny-invariant@^1.0.2:
   version "1.1.0"
@@ -13704,6 +14081,14 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
+
+unicode-trie@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/unicode-trie/-/unicode-trie-0.3.1.tgz#d671dddd89101a08bac37b6a5161010602052085"
+  integrity sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=
+  dependencies:
+    pako "^0.2.5"
+    tiny-inflate "^1.0.0"
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
WHAT CHANGED:

adding ability to share itineraries-- new 'link' button in the navbar when viewing itineraries in **edit mode**
- click on the link icon and should copy and paste the url of the new shared link -- CAUTION: the link is NOT local host

- log out, then paste the LOCAL HOST link; it should allow you to view the itinerary in special read-only mode
---> disabled features (side itinerary edit button, adding new search activities (we DO allow searching though)). 

existing behaviour that should NOT change:
- any logged out user should NOT be able to go to any other URLs (e.g. /home) other than /about and / and /shared
- and any logged in user should be able to view it as well, and also visit whatever URLs are allowed for logged in users

- trying to access any INVALID shared itinerary should result in a dialog that says the itinerary is INVALID