### PR TITLE
Andre/code cleanup 2

### DIFF
--- a/trippo/src/components/itineraryEdit/Day.tsx
+++ b/trippo/src/components/itineraryEdit/Day.tsx
@@ -178,7 +178,7 @@ const Day: FC<Props> = ({
             sm={12}
             xs={12}
           >
-            {!isReadOnly && dayActivities.length > 0 && (
+            {((!isReadOnly && dayActivities.length > 0) || edit) &&  (
               <sc.EditButton $edit={edit} $hasMarginTop={dayCost === 0} onClick={handleEditView}>
                 {edit ? "Done" : "Edit"}
               </sc.EditButton>


### PR DESCRIPTION
fixing bug with edit button:

to reproduce: select day with 1 activity present, click Edit, delete that activity, notice the edit button disappears.

With new fix, exisiting edit button functionality should work (can edit with mutliple activities present)-- the edit button should now not disappear when there are no activities present but you're still editing. 